### PR TITLE
6.10 runtime

### DIFF
--- a/org.kde.arianna.json
+++ b/org.kde.arianna.json
@@ -63,8 +63,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/frameworks/6.18/baloo-6.18.0.tar.xz",
-                    "sha256": "680b01ed7c789b7ef0ee8f14faffaf2e8bdf87a56a26eb2a6f95a472e5630903",
+                    "url": "https://download.kde.org/stable/frameworks/6.19/baloo-6.19.0.tar.xz",
+                    "sha256": "af3d5d85d4ed22963564fa6cc5557d489f17cba30d58308bba8c4c93d4e84688",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8762,


### PR DESCRIPTION
- **Update runtime and qtwebengine to 6.10**
- **Remove Kirigami Addons as it is now in the runtime**
- **Update baloo to 6.19.0**
